### PR TITLE
feat(world): save and restore resources states

### DIFF
--- a/components/growth/Growth.gd
+++ b/components/growth/Growth.gd
@@ -36,6 +36,13 @@ func on_collect() -> void:
 	quantity = 0
 	timer.start(tick_time)
 
+
+func restore(quantity: int, time_left: int) -> void:
+	self.quantity = quantity
+	self.timer.stop()
+	self.timer.start(time_left)
+
+
 #endregion login
 
 

--- a/components/growth/Growth.gd
+++ b/components/growth/Growth.gd
@@ -43,7 +43,8 @@ func on_collect() -> void:
 
 func _on_timeout() -> void:
 	quantity += 1
-	if quantity >= max_quantity:
-		timer.stop()
+	timer.stop()
+	if quantity < max_quantity:
+		timer.start(tick_time)
 
 #endregion signal

--- a/objects/item/gold/resource/GoldResource.gd
+++ b/objects/item/gold/resource/GoldResource.gd
@@ -2,9 +2,6 @@ class_name GoldResource
 extends ItemResource
 
 
-@onready var growth: Growth = %Growth
-
-
 #region logic
 
 func collect() -> ItemData:

--- a/objects/item/gold/resource/GoldResource.tscn
+++ b/objects/item/gold/resource/GoldResource.tscn
@@ -1,10 +1,9 @@
-[gd_scene load_steps=12 format=3 uid="uid://2efo5oxjvdjq"]
+[gd_scene load_steps=11 format=3 uid="uid://2efo5oxjvdjq"]
 
 [ext_resource type="PackedScene" uid="uid://do4jmalkiwfch" path="res://objects/resource/ItemResource.tscn" id="1_1ccyc"]
 [ext_resource type="Shader" path="res://objects/resource/ItemResource.gdshader" id="2_bqr41"]
 [ext_resource type="Script" path="res://objects/item/gold/resource/GoldResource.gd" id="2_f55gb"]
 [ext_resource type="Texture2D" uid="uid://metqx6jtxy7k" path="res://objects/resource/resources.png" id="3_n2pl3"]
-[ext_resource type="PackedScene" uid="uid://bouxt3dlc0w8o" path="res://components/growth/Growth.tscn" id="5_npr4v"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_800oj"]
 size = Vector2(15, 15)
@@ -66,8 +65,7 @@ material = SubResource("ShaderMaterial_868tp")
 sprite_frames = SubResource("SpriteFrames_ugatd")
 animation = &"2"
 
-[node name="Growth" parent="." index="3" instance=ExtResource("5_npr4v")]
-unique_name_in_owner = true
+[node name="Growth" parent="." index="3"]
 tick_time = 600
 max_quantity = 2
 

--- a/objects/item/stone/resource/StoneResource.gd
+++ b/objects/item/stone/resource/StoneResource.gd
@@ -2,9 +2,6 @@ class_name StoneResource
 extends ItemResource
 
 
-@onready var growth: Growth = %Growth
-
-
 #region logic
 
 func collect() -> ItemData:

--- a/objects/item/stone/resource/StoneResource.tscn
+++ b/objects/item/stone/resource/StoneResource.tscn
@@ -1,10 +1,9 @@
-[gd_scene load_steps=12 format=3 uid="uid://bfhoxhkvf1uy4"]
+[gd_scene load_steps=11 format=3 uid="uid://bfhoxhkvf1uy4"]
 
 [ext_resource type="PackedScene" uid="uid://do4jmalkiwfch" path="res://objects/resource/ItemResource.tscn" id="1_y5cwq"]
 [ext_resource type="Texture2D" uid="uid://metqx6jtxy7k" path="res://objects/resource/resources.png" id="2_pthtu"]
 [ext_resource type="Script" path="res://objects/item/stone/resource/StoneResource.gd" id="2_vvwcf"]
 [ext_resource type="Shader" path="res://objects/resource/ItemResource.gdshader" id="3_fnc6o"]
-[ext_resource type="PackedScene" uid="uid://bouxt3dlc0w8o" path="res://components/growth/Growth.tscn" id="5_e4tj5"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_x7ujr"]
 size = Vector2(15, 15)
@@ -66,8 +65,7 @@ material = SubResource("ShaderMaterial_qhwso")
 sprite_frames = SubResource("SpriteFrames_fbakm")
 animation = &"2"
 
-[node name="Growth" parent="." index="3" instance=ExtResource("5_e4tj5")]
-unique_name_in_owner = true
+[node name="Growth" parent="." index="3"]
 tick_time = 300
 initial_quantity = 2
 max_quantity = 2

--- a/objects/resource/ItemResource.gd
+++ b/objects/resource/ItemResource.gd
@@ -38,9 +38,7 @@ func get_data() -> ResourceData:
 
 
 func restore(data: ResourceData) -> void:
-	growth.quantity = data.quantity
-	growth.timer.stop()
-	growth.timer.start(data.time_left)
+	growth.restore(data.quantity, data.time_left)
 
 #endregion logic
 

--- a/objects/resource/ItemResource.gd
+++ b/objects/resource/ItemResource.gd
@@ -5,6 +5,7 @@ extends StaticBody2D
 @onready var animated_sprite: AnimatedSprite2D = %AnimatedSprite
 @onready var information_panel: PanelContainer = %InformationPanel
 @onready var key_label: Label = %KeyLabel
+@onready var growth: Growth = %Growth
 
 
 #region built-in
@@ -32,6 +33,8 @@ func hide_as_collectable() -> void:
 	information_panel.hide()
 
 
+func get_data() -> ResourceData:
+	return ResourceData.new(growth.quantity, growth.timer.time_left)
 
 #endregion logic
 

--- a/objects/resource/ItemResource.gd
+++ b/objects/resource/ItemResource.gd
@@ -36,6 +36,12 @@ func hide_as_collectable() -> void:
 func get_data() -> ResourceData:
 	return ResourceData.new(growth.quantity, growth.timer.time_left)
 
+
+func restore(data: ResourceData) -> void:
+	growth.quantity = data.quantity
+	growth.timer.stop()
+	growth.timer.start(data.time_left)
+
 #endregion logic
 
 #region abstract

--- a/objects/resource/ItemResource.tscn
+++ b/objects/resource/ItemResource.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=4 format=3 uid="uid://do4jmalkiwfch"]
+[gd_scene load_steps=5 format=3 uid="uid://do4jmalkiwfch"]
 
 [ext_resource type="Script" path="res://objects/resource/ItemResource.gd" id="1_8hg5e"]
 [ext_resource type="Shader" path="res://objects/resource/ItemResource.gdshader" id="2_m70ba"]
+[ext_resource type="PackedScene" uid="uid://bouxt3dlc0w8o" path="res://components/growth/Growth.tscn" id="3_67q3v"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_5folb"]
 resource_local_to_scene = true
@@ -57,3 +58,6 @@ size_flags_horizontal = 4
 theme_override_colors/font_color = Color(1, 0, 0, 1)
 theme_override_font_sizes/font_size = 12
 text = "[?]"
+
+[node name="Growth" parent="." instance=ExtResource("3_67q3v")]
+unique_name_in_owner = true

--- a/objects/resource/ResourceData.gd
+++ b/objects/resource/ResourceData.gd
@@ -1,0 +1,11 @@
+class_name ResourceData
+extends Node
+
+
+var quantity: int
+var time_left: int
+
+
+func _init(quantity: int, time_left: int) -> void:
+	self.quantity = quantity
+	self.time_left = time_left

--- a/scenes/levels/camp/Camp.gd
+++ b/scenes/levels/camp/Camp.gd
@@ -15,6 +15,11 @@ func _ready() -> void:
 		_init_house(idx, house, progression)
 		_connect_objectives(house)
 
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_WM_CLOSE_REQUEST:
+		_save()
+
 #endregion built-in
 
 

--- a/scenes/levels/debug/DebugPlanet.gd
+++ b/scenes/levels/debug/DebugPlanet.gd
@@ -13,6 +13,7 @@ func _ready() -> void:
 	InventoryStorage.restore(progression.items)
 	ObjectivesManager.restore(progression.finished_objectives)
 	player.position = progression.player_position
+	_restore_resources(progression.resources)
 	camera_2d.reset_smoothing()
 
 	ObjectivesManager.auto_connect(player)
@@ -37,6 +38,15 @@ func _save() -> void:
 	progression.finished_objectives = ObjectivesManager.get_finished_objectives()
 	progression.resources = _get_resources()
 	ProgressionService.save(progression)
+
+
+func _restore_resources(data: Array[ResourceData]) -> void:
+	for i in resources.get_child_count():
+		var resourceData = data[i]
+		if resourceData != null:
+			var node = resources.get_child(i)
+			if node is ItemResource:
+				node.restore(resourceData)
 
 
 func _get_resources() -> Array[ResourceData]:

--- a/scenes/levels/debug/DebugPlanet.gd
+++ b/scenes/levels/debug/DebugPlanet.gd
@@ -4,6 +4,7 @@ extends Node2D
 @onready var player: Player = %Player
 @onready var camera_2d: Camera2D = %Camera2D
 @onready var camp_respawn: Node2D = %CampRespawn
+@onready var resources: Node2D = %Resources
 
 
 func _ready() -> void:
@@ -34,4 +35,17 @@ func _save() -> void:
 	progression.player_position = camp_respawn.position
 	progression.items = InventoryStorage.get_items()
 	progression.finished_objectives = ObjectivesManager.get_finished_objectives()
+	progression.resources = _get_resources()
 	ProgressionService.save(progression)
+
+
+func _get_resources() -> Array[ResourceData]:
+	var typed: Array[ResourceData]
+	typed.assign(resources.get_children().map(_to_resource_data))
+	return typed
+
+
+func _to_resource_data(node: Node) -> ResourceData:
+	if (node is ItemResource):
+		return node.get_data()
+	return null

--- a/scenes/levels/debug/DebugPlanet.gd
+++ b/scenes/levels/debug/DebugPlanet.gd
@@ -24,6 +24,11 @@ func _on_camp_entered(body: Node2D) -> void:
 		SceneTransition.change_scene("res://scenes/levels/camp/Camp.tscn", _save)
 
 
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_WM_CLOSE_REQUEST:
+		_save()
+
+
 func _save() -> void:
 	var progression = ProgressionService.data
 	progression.player_position = camp_respawn.position

--- a/scenes/levels/debug/DebugPlanet.tscn
+++ b/scenes/levels/debug/DebugPlanet.tscn
@@ -86,6 +86,7 @@ position = Vector2(837, 35)
 position = Vector2(705, -21)
 
 [node name="Resources" type="Node2D" parent="."]
+unique_name_in_owner = true
 
 [node name="StoneResource1" parent="Resources" instance=ExtResource("5_bw6g5")]
 position = Vector2(25, -117)

--- a/services/save/Progression.gd
+++ b/services/save/Progression.gd
@@ -6,15 +6,18 @@ var player_position: Vector2
 var items: Array[ItemData]
 var houses_levels: Array[int]
 var finished_objectives: Array[String]
+var resources: Array[ResourceData]
 
 
 func _init(
 	player_position: Vector2,
 	items: Array[ItemData],
 	houses_levels: Array[int],
-	finished_objectives: Array[String]
+	finished_objectives: Array[String],
+	resources: Array[ResourceData]
 ):
 	self.player_position = player_position
 	self.items = items
 	self.houses_levels = houses_levels
 	self.finished_objectives = finished_objectives
+	self.resources = resources

--- a/services/save/ProgressionService.gd
+++ b/services/save/ProgressionService.gd
@@ -33,7 +33,7 @@ func _load():
 		file.close()
 		return data
 	else:
-		return Progression.new(Vector2.ZERO, [], [], [])
+		return Progression.new(Vector2.ZERO, [], [], [], [])
 
 
 func _serialize(progression: Progression) -> String:
@@ -42,7 +42,8 @@ func _serialize(progression: Progression) -> String:
 		"player_y": progression.player_position.y,
 		"items": progression.items.map(_serialize_item),
 		"houses_levels": progression.houses_levels,
-		"finished_objectives": progression.finished_objectives
+		"finished_objectives": progression.finished_objectives,
+		"resources": progression.resources.map(_serialize_resource)
 	})
 
 
@@ -52,7 +53,8 @@ func _parse(json: String) -> Progression:
 		Vector2(dict["player_x"], dict["player_y"]),
 		_parse_items(dict.get("items", [])),
 		_parse_houses_levels(dict.get("houses_levels", [])),
-		_parse_finished_objectives(dict.get("finished_objectives", []))
+		_parse_finished_objectives(dict.get("finished_objectives", [])),
+		_parse_resources(dict.get("resources", []))
 	)
 
 
@@ -92,10 +94,30 @@ func _parse_item(itemDict: Dictionary) -> ItemData:
 	return ItemData.new(ref, quantity)
 
 
+func _parse_resources(resources: Array) -> Array[ResourceData]:
+	var typedResources: Array[ResourceData]
+	typedResources.assign(resources.map(_parse_resource))
+	return typedResources
+
+
+func _parse_resource(resourceDict: Dictionary) -> ResourceData:
+	return ResourceData.new(
+		resourceDict["quantity"],
+		resourceDict["time_left"]
+	)
+
+
 func _serialize_item(item: ItemData) -> Dictionary:
 	return {
 		"code": item.ref.code,
 		"quantity": item.quantity
+	}
+
+
+func _serialize_resource(resource: ResourceData) -> Dictionary:
+	return {
+		"quantity": resource.quantity,
+		"time_left": resource.time_left
 	}
 
 #endregion private


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Save states of resources in order to restore them when starting the game later.

## Motivation and Context

We want to be able to play again and again, so we have to save the world state.

## How has this been tested?

Manually 🤷 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- My change requires a change to the documentation.
- I have updated the documentation accordingly.